### PR TITLE
Add typescript definitions for the bundledPrinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 ### vNext
-- ...
+- Add typescript definitions for the bundledPrinter [PR #63](https://github.com/apollographql/graphql-tag/pull/63)
 
 ### v1.3.1
 - Making sure not to log deprecation warnings for internal use of deprecated module [jnwng](https://github.com/jnwng) addressing [#54](https://github.com/apollographql/graphql-tag/issues/54#issuecomment-283301475)

--- a/bundledPrinter.d.ts
+++ b/bundledPrinter.d.ts
@@ -1,0 +1,1 @@
+export declare function print(ast: any): string;


### PR DESCRIPTION
There's no any right now and it breaks typescript compilation in some cases. 

@jnwng We need it in `apollo-angular`