### PR TITLE
Support use case of gql(``) vs gql``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 ### vNEXT
+- Add support for calling `gql` as a function [matthewerwin](https://github.com/matthewerwin) in [PR #66](https://github.com/apollographql/graphql-tag/pull/66)
 
 ### v2.0.0
 Restore dependence on `graphql` module [abhiaiyer91](https://github.com/abhiaiyer91) in [PR #46](https://github.com/apollographql/graphql-tag/pull/46) addressing [#6](https://github.com/apollographql/graphql-tag/issues/6)

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ function gql(/* arguments */) {
   var literals = args[0];
 
   // We always get literals[0] and then matching post literals for each arg given
-  var result = literals[0];
+  var result = (typeof(literals) === "string") ? literals : literals[0];
 
   for (var i = 1; i < args.length; i++) {
     if (args[i] && args[i].kind && args[i].kind === 'Document') {

--- a/test.js
+++ b/test.js
@@ -9,6 +9,10 @@ const assert = require('chai').assert;
       assert.equal(gql`{ testQuery }`.kind, 'Document');
     });
 
+    it('parses queries when called as a function', () => {
+      assert.equal(gql('{ testQuery }').kind, 'Document');
+    });
+
     it('parses queries with weird substitutions', () => {
       const obj = {};
       assert.equal(gql`{ field(input: "${obj.missing}") }`.kind, 'Document');


### PR DESCRIPTION
Current implementation throws an exception that the query isn't valid without providing information that the document was reduced to a single character by the implementation. Either the software should elegantly handle the case when parenthesis are added to the function  call or else return a useful error on usage.