### PR TITLE
Fix loader to work with source files using any EOL separators

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -3,11 +3,13 @@
 const os = require('os');
 const gql = require('./src');
 
+const ANY_EOL = /\r?\n/
+
 // Takes `source` (the source GraphQL query string)
 // and `doc` (the parsed GraphQL document) and tacks on
 // the imported definitions.
 function expandImports(source, doc) {
-  const lines = source.split(os.EOL);
+  const lines = source.split(ANY_EOL);
   let outputCode = `
     var names = {};
     function unique(defs) {


### PR DESCRIPTION
Source EOL separators do not need to match OS default EOL separator. For example, it's common in Git for WIndows to commit LF and checkout as-is, so the source files do use LF (\n), and not CRLF (\r\n).