### PR TITLE
Make parsing line endings kind agnostic

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -7,7 +7,7 @@ const gql = require('./src');
 // and `doc` (the parsed GraphQL document) and tacks on
 // the imported definitions.
 function expandImports(source, doc) {
-  const lines = source.split(os.EOL);
+  const lines = source.split(/\r\n|\r|\n/);
   let outputCode = `
     var names = {};
     function unique(defs) {


### PR DESCRIPTION
At the moment Webpack loader parsing will fail if `.graphql` files have Unix line endings on Windows machine, because the parser will view the whole file as one line. This patch makes parser correctly understand lines no matter what kind of line endings is used, Unix, Mac or Windows.