### PR TITLE
Add flow support

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./src/index.js",
   "jsnext:main": "./src/index.js",
   "scripts": {
-    "bundle": "rollup -c",
+    "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
     "test": "mocha --require babel-register",
     "prepublish": "npm run bundle"
   },

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,7 @@
+// @flow
+
+import type { DocumentNode } from 'graphql';
+
+declare export default function gql(literals: any, ...placeholders: any[]): DocumentNode;
+declare export function resetCaches(): void;
+declare export function disableFragmentWarnings(): void;


### PR DESCRIPTION
1. Declared `index.js.flow` in `src` directory.
2. On `bundle` it copies given flow definition to lib directory under the same name as `main` script in `package.json`.
3. Works out of the box with flow projects that uses `graphql-tag`.

Resolves #97 