### PR TITLE
feat(descriptors): add support for descriptors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 var parser = require('graphql/language/parser');
+var buildASTSchema = require('graphql/utilities/buildASTSchema');
 
 var parse = parser.parse;
+var getDescription = buildASTSchema.getDescription;
 
 // Strip insignificant whitespace
 // Note that this could do a lot more, such as reorder fields etc.
@@ -81,6 +83,14 @@ function stripLoc(doc, removeLocAtThisLevel) {
     return doc.map(function (d) {
       return stripLoc(d, removeLocAtThisLevel);
     });
+  }
+
+  if (!doc.description) {
+    var description = getDescription(doc);
+
+    if (description) {
+      doc.description = description;
+    }
   }
 
   if (docType !== '[object Object]') {

--- a/test.js
+++ b/test.js
@@ -433,5 +433,19 @@ const assert = require('chai').assert;
     //   `);
     // });
 
+    describe('descriptors', function() {
+      it('adds comments as descriptors', function() {
+        const ast = gql`
+          # This is a descriptor
+          type Foo {
+            # This is another descriptor
+            bar: String
+          }
+        `;
+
+        assert.equal(ast.definitions[0].description, 'This is a descriptor');
+      })
+    })
+
   });
 });

--- a/test.js
+++ b/test.js
@@ -436,14 +436,16 @@ const assert = require('chai').assert;
     describe('descriptors', function() {
       it('adds comments as descriptors', function() {
         const ast = gql`
-          # This is a descriptor
+          # This is a type descriptor
           type Foo {
-            # This is another descriptor
+            # This is a field descriptor
             bar: String
+            baz: Int
           }
         `;
-
-        assert.equal(ast.definitions[0].description, 'This is a descriptor');
+        assert.equal(ast.definitions[0].description, 'This is a type descriptor');
+        assert.equal(ast.definitions[0].fields[0].description, 'This is a field descriptor');
+        assert.equal(ast.definitions[0].fields[1].description, undefined);
       })
     })
 


### PR DESCRIPTION
Connects to https://github.com/apollographql/graphql-tag/issues/81

This will add support for descriptors in schema files:

```graphql
# This is a type descriptor
type Foo {
  # This is a field descriptor
  bar: String
  baz: Int
}
```

@stubailo, could you have a look at this? Or maybe @jnwng. Thanks!
