### PR TITLE
Support cross-platform EOL formats

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -7,7 +7,7 @@ const gql = require('./src');
 // and `doc` (the parsed GraphQL document) and tacks on
 // the imported definitions.
 function expandImports(source, doc) {
-  const lines = source.split(/\r\n|\r|\n/);
+  const lines = source.split(/(?:\r?\n)+/);
   let outputCode = `
     var names = {};
     function unique(defs) {
@@ -33,7 +33,7 @@ function expandImports(source, doc) {
       const appendDef = `doc.definitions = doc.definitions.concat(unique(${parseDocument}.definitions));`;
       outputCode += appendDef + os.EOL;
     }
-    return (line.length !== 0 && line[0] !== '#');
+    return line[0] !== '#';
   });
 
   return outputCode;


### PR DESCRIPTION
Fix issue 61 for files written in one OS and read in another.
Add test.

This compliments change made in https://github.com/apollographql/graphql-tag/commit/bcff86eb9daedf0dd92bfbbb3fafbf0d12b0bcbe.