### PR TITLE
loader: Filter out unused imported fragments

### DIFF
--- a/test.js
+++ b/test.js
@@ -70,6 +70,35 @@ const assert = require('chai').assert;
       assert.equal(definitions[1].kind, 'FragmentDefinition');
     });
 
+    it('removes unused fragments', () => {
+      const query = `#import "./fragment_definition.graphql"
+        query {
+          author {
+            ...authorDetails
+          }
+        }`;
+      const jsSource = loader.call({ cacheable() {} }, query);
+      const oldRequire = require;
+      const module = { exports: undefined };
+      const require = (path) => {
+        assert.equal(path, './fragment_definition.graphql');
+        return gql`
+          fragment authorDetails on Author {
+            firstName
+            lastName
+          }
+          fragment unusedFragment on Author {
+            other
+          }`;
+      };
+      eval(jsSource);
+      assert.equal(module.exports.kind, 'Document');
+      const definitions = module.exports.definitions;
+      assert.equal(definitions.length, 2);
+      assert.equal(definitions[0].kind, 'OperationDefinition');
+      assert.equal(definitions[1].kind, 'FragmentDefinition');
+    });
+
     it('does not complain when presented with normal comments', (done) => {
       assert.doesNotThrow(() => {
         const query = `#normal comment


### PR DESCRIPTION
This can help with #102. After importing fragments from another file, we can strip out the ones that are not referenced by any of the operations.