### PR TITLE
Webpack: support multiple query definitions per query file

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -39,14 +39,86 @@ function expandImports(source, doc) {
   return outputCode;
 }
 
+// Collect any fragment/type references from a node, adding them to the refs Set
+function collectFragmentReferences(node, refs) {
+  if (node.kind === "FragmentSpread") {
+    refs.add(node.name.value);
+  } else if (node.kind === "VariableDefinition") {
+    const type = node.type;
+    if (type.kind === "NamedType") {
+      refs.add(type.name.value);
+    }
+  }
+
+  if (node.selectionSet) {
+    for (const selection of node.selectionSet.selections) {
+      collectFragmentReferences(selection, refs);
+    }
+  }
+
+  if (node.variableDefinitions) {
+    for (const def of node.variableDefinitions) {
+      collectFragmentReferences(def, refs);
+    }
+  }
+
+  if (node.definitions) {
+    for (const def of node.definitions) {
+      collectFragmentReferences(def, refs);
+    }
+  }
+}
+
 module.exports = function(source) {
   this.cacheable();
   const doc = gql`${source}`;
-  const outputCode = `
+  let outputCode = `
+    function oneQuery(doc, refs, operationName) {
+      const newDoc = Object.assign({}, doc);
+      // Filter out operations
+      newDoc.definitions = newDoc.definitions.filter(function(def) {
+        return def.kind !== "OperationDefinition" || def.name.value === operationName;
+      });
+      
+      // Now, for the operation we're running, only include fragments it references
+      const refsSet = new Set(refs);
+      newDoc.definitions = newDoc.definitions.filter(function(def) {
+        return def.kind !== "FragmentDefinition" || refsSet.has(def.name.value);
+      });
+    
+      return newDoc;
+    }
+
     var doc = ${JSON.stringify(doc)};
     doc.loc.source = ${JSON.stringify(doc.loc.source)};
+    module.exports = {};
   `;
-  const importOutputCode = expandImports(source, doc);
 
-  return outputCode + os.EOL + importOutputCode + os.EOL + `module.exports = doc;`;
+  // Allow multiple query/mutation definitions in a file. This parses out dependencies
+  // at compile time, and then uses those at load time to create minimal query documents
+  // We cannot do the latter at compile time due to how the #import code works.
+  let operationCount = 0;
+  for (const op of doc.definitions) {
+    if (op.kind === "OperationDefinition") {
+      ++operationCount;
+      const opName = op.name.value;
+      const opQueryRefs = new Set();
+      collectFragmentReferences(op, opQueryRefs);
+      outputCode += `
+      var ${opName}Refs = ${JSON.stringify(Array.from(opQueryRefs))};
+      module.exports["${opName}"] = oneQuery(doc, ${opName}Refs, "${opName}");
+      `
+    }
+  }
+
+  if (operationCount <= 1) {
+    outputCode += `
+      module.exports = doc;
+    `
+  }
+
+  const importOutputCode = expandImports(source, doc);
+  const allCode = outputCode + os.EOL + importOutputCode + os.EOL;
+
+  return allCode;
 };

--- a/loader.js
+++ b/loader.js
@@ -71,36 +71,36 @@ module.exports = function(source) {
       if (node.kind === "FragmentSpread") {
         refs.add(node.name.value);
       } else if (node.kind === "VariableDefinition") {
-        const type = node.type;
+        var type = node.type;
         if (type.kind === "NamedType") {
           refs.add(type.name.value);
         }
       }
 
       if (node.selectionSet) {
-        for (const selection of node.selectionSet.selections) {
+        for (var selection of node.selectionSet.selections) {
           collectFragmentReferences(selection, refs);
         }
       }
 
       if (node.variableDefinitions) {
-        for (const def of node.variableDefinitions) {
+        for (var def of node.variableDefinitions) {
           collectFragmentReferences(def, refs);
         }
       }
 
       if (node.definitions) {
-        for (const def of node.definitions) {
+        for (var def of node.definitions) {
           collectFragmentReferences(def, refs);
         }
       }
     }
 
-    const definitionRefs = {};
+    var definitionRefs = {};
     (function extractReferences() {
-      for (const def of doc.definitions) {
+      for (var def of doc.definitions) {
         if (def.name) {
-          const refs = new Set();
+          var refs = new Set();
           collectFragmentReferences(def, refs);
           definitionRefs[def.name.value] = refs;
         }
@@ -115,24 +115,24 @@ module.exports = function(source) {
     
     function oneQuery(doc, operationName) {
       // Copy the DocumentNode, but clear out the definitions
-      const newDoc = Object.assign({}, doc);
+      var newDoc = Object.assign({}, doc);
 
-      const op = findOperation(doc, operationName);
+      var op = findOperation(doc, operationName);
       newDoc.definitions = [op];
       
       // Now, for the operation we're running, find any fragments referenced by
       // it or the fragments it references
-      const opRefs = definitionRefs[operationName] || new Set();
+      var opRefs = definitionRefs[operationName] || new Set();
       let allRefs = new Set();
       let newRefs = new Set(opRefs);
       while (newRefs.size > 0) {
-        const prevRefs = newRefs;
+        var prevRefs = newRefs;
         newRefs = new Set();
 
         for (let refName of prevRefs) {
           if (!allRefs.has(refName)) {
             allRefs.add(refName);
-            const childRefs = definitionRefs[refName] || new Set();
+            var childRefs = definitionRefs[refName] || new Set();
             for (let childRef of childRefs) {
               newRefs.add(childRef);
             }
@@ -141,7 +141,7 @@ module.exports = function(source) {
       }
 
       for (let refName of allRefs) {
-        const op = findOperation(doc, refName);
+        var op = findOperation(doc, refName);
         if (op) {
           newDoc.definitions.push(op);
         }

--- a/loader.js
+++ b/loader.js
@@ -150,7 +150,7 @@ module.exports = function(source) {
       return newDoc;
     }
 
-    module.exports = {};
+    module.exports = doc;
     `
 
     for (const op of doc.definitions) {

--- a/loader.js
+++ b/loader.js
@@ -123,8 +123,8 @@ module.exports = function(source) {
       // Now, for the operation we're running, find any fragments referenced by
       // it or the fragments it references
       var opRefs = definitionRefs[operationName] || new Set();
-      let allRefs = new Set();
-      let newRefs = new Set(opRefs);
+      var allRefs = new Set();
+      var newRefs = new Set(opRefs);
       while (newRefs.size > 0) {
         var prevRefs = newRefs;
         newRefs = new Set();

--- a/loader.js
+++ b/loader.js
@@ -78,33 +78,33 @@ module.exports = function(source) {
       }
 
       if (node.selectionSet) {
-        for (var selection of node.selectionSet.selections) {
+        node.selectionSet.selections.forEach(function(selection) {
           collectFragmentReferences(selection, refs);
-        }
+        });
       }
 
       if (node.variableDefinitions) {
-        for (var def of node.variableDefinitions) {
+        node.variableDefinitions.forEach(function(def) {
           collectFragmentReferences(def, refs);
-        }
+        });
       }
 
       if (node.definitions) {
-        for (var def of node.definitions) {
+        node.definitions.forEach(function(def) {
           collectFragmentReferences(def, refs);
-        }
+        });
       }
     }
 
     var definitionRefs = {};
     (function extractReferences() {
-      for (var def of doc.definitions) {
+      doc.definitions.forEach(function(def) {
         if (def.name) {
           var refs = new Set();
           collectFragmentReferences(def, refs);
           definitionRefs[def.name.value] = refs;
         }
-      }
+      });
     })();
 
     function findOperation(doc, name) {
@@ -129,23 +129,23 @@ module.exports = function(source) {
         var prevRefs = newRefs;
         newRefs = new Set();
 
-        for (let refName of prevRefs) {
+        prevRefs.forEach(function(refName) {
           if (!allRefs.has(refName)) {
             allRefs.add(refName);
             var childRefs = definitionRefs[refName] || new Set();
-            for (let childRef of childRefs) {
+            childRefs.forEach(function(childRef) {
               newRefs.add(childRef);
-            }
+            });
           }
-        }
+        });
       }
 
-      for (let refName of allRefs) {
+      allRefs.forEach(function(refName) {
         var op = findOperation(doc, refName);
         if (op) {
           newDoc.definitions.push(op);
         }
-      }
+      });
       
       return newDoc;
     }


### PR DESCRIPTION
This allows them to be imported by name:
```
// query.gql
query MyQuery1 {
  ...
}

query MyQuery2 {
  ...
}

// some.js
import { MyQuery1, MyQuery2 } from 'query.gql'

// or
const Queries = require('query.gql');
...Queries.MyQuery1
...Queries.MyQuery2
```

In the case where there's only a single query, it remains backwards compatible. I'm not sure if this is desired or not... I considered putting it behind a loader option, but thought I'd ask here.

I believe this solves #119, but the wording in that issue is unclear to me so I'm not sure.