### PR TITLE
gql() helper return value with DocumentNode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-export default function gql(literals: any, ...placeholders: any[]): any;
+export default function gql(literals: any, ...placeholders: any[]): DocumentNode;
 export function resetCaches(): void;
 export function disableFragmentWarnings(): void;


### PR DESCRIPTION
Stronger typing, avoid any for "no-any" TypeScript projects.