### PR TITLE
Typescript type safety

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
 
-export default function gql(literals: any, ...placeholders: any[]): DocumentNode;
+export default function gql(template: TemplateStringsArray, ...substitutions: any[]): DocumentNode;
 export function resetCaches(): void;
 export function disableFragmentWarnings(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
-export default function gql(literals: any, ...placeholders: any[]): any;
+import { DocumentNode } from 'graphql';
+
+export default function gql(literals: any, ...placeholders: any[]): DocumentNode;
 export function resetCaches(): void;
 export function disableFragmentWarnings(): void;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/apollostack/graphql-tag/issues"
   },
   "homepage": "https://github.com/apollostack/graphql-tag#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@types/graphql": ">=0.8.6 <=0.11.7"
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/graphql@>=0.8.6 <=0.11.7":
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.11.7.tgz#da39a2f7c74e793e32e2bb7b3b68da1691532dd5"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -527,11 +531,11 @@ globals@^9.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.0.tgz#29e4f83d85e79245f8496f40a2232e6e5c5baaee"
+graphql@^0.11.0:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
   dependencies:
-    iterall "^1.1.0"
+    iterall "1.1.3"
 
 growl@1.9.2:
   version "1.9.2"
@@ -577,9 +581,9 @@ is-finite@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
-iterall@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -764,9 +768,9 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-rollup@^0.42.0:
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.42.0.tgz#56e791b3a2f3dd7190bbb80a375675f2fe0f9b23"
+rollup@^0.45.0:
+  version "0.45.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.45.2.tgz#63a284c2b31234656f24e9e9717fabb6a7f0fa43"
   dependencies:
     source-map-support "^0.4.0"
 


### PR DESCRIPTION
Closes #138 

I used the broadest possible version range for `@types/graphql` that exports `DocumentNode` to get the biggest chance of deduping.

Also changed the string tag signature to not use `any`, like [`String.raw`](https://github.com/Microsoft/TypeScript/blob/0477f91dbad209809363323042f34926d3a6e175/lib/lib.es2015.core.d.ts#L544).