### PR TITLE
[Loader] Fix: Track refs to NonNullType

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -75,6 +75,10 @@ module.exports = function(source) {
         if (type.kind === "NamedType") {
           refs.add(type.name.value);
         }
+
+        if (type.kind === 'NonNullType' && type.type.kind === 'NamedType') {
+          refs.add(type.type.name.value)
+        }
       }
 
       if (node.selectionSet) {


### PR DESCRIPTION
Hi! I spent yesterday updating my package babel-plugin-inline-import-graphql-ast to support multiple operations like this package. In doing so, reused a lot of the code from here and noticed that nullable variables were being tracked but non-nullable variables were not. I assume that was not the intention.

I haven't added a test because I'm not familiar with your test configuration (or webpack in general) and didn't see any existing tests covering the variable reference tracking (which is why I'm assuming this slipped through in the first place. If someone can give me any pointers I'm willing to attempt to make some tests.

I've tested it manually in my project and verified that without this code, the Set() will not contain names for non-nullable variables, and with this code it does.