### PR TITLE
Adding compatibility check for all supported versions of `graphql`

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,0 +1,10 @@
+
+graphql-0.11:
+  name: graphql
+  versions: "^0.9.0 || ^0.10.0 || ^0.11.0"
+  commands: mocha test/graphql.js test/graphql-v0.11.js
+
+graphql-0.12:
+  name: graphql
+  versions: "^0.12.0 || ^0.13.0"
+  commands: mocha test/graphql.js test/graphql-v0.12.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "6"
   - "5"
   - "4"
+script:
+    - yarn test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsnext:main": "./src/index.js",
   "scripts": {
     "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
-    "test": "tav --ci && mocha test/graphql.js test/graphql-v0.12.js",
+    "test": "tav --ci --compat && mocha test/graphql.js test/graphql-v0.12.js",
     "prepublish": "npm run bundle"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsnext:main": "./src/index.js",
   "scripts": {
     "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
-    "test": "tav",
+    "test": "tav --ci && mocha test/graphql.js test/graphql-v0.12.js",
     "prepublish": "npm run bundle"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "chai": "^4.0.2",
-    "graphql": "0.13",
+    "graphql": "^0.13.0",
     "mocha": "^3.4.1",
     "rollup": "^0.45.0",
     "test-all-versions": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsnext:main": "./src/index.js",
   "scripts": {
     "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
-    "test": "tav --ci --compat && mocha test/graphql.js test/graphql-v0.12.js",
+    "test": "mocha test/graphql.js test/graphql-v0.12.js && tav --ci --compat",
     "prepublish": "npm run bundle"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsnext:main": "./src/index.js",
   "scripts": {
     "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
-    "test": "mocha --require babel-register",
+    "test": "tav",
     "prepublish": "npm run bundle"
   },
   "repository": {
@@ -25,11 +25,12 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "chai": "^4.0.2",
-    "graphql": "^0.11.0",
+    "graphql": "0.13",
     "mocha": "^3.4.1",
-    "rollup": "^0.45.0"
+    "rollup": "^0.45.0",
+    "test-all-versions": "^3.3.2"
   },
   "peerDependencies": {
-    "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0"
+    "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0"
   }
 }

--- a/test/graphql-v0.11.js
+++ b/test/graphql-v0.11.js
@@ -1,0 +1,137 @@
+const gqlRequire = require("../src");
+const gqlDefault = require("../src").default;
+const assert = require("chai").assert;
+
+[gqlRequire, gqlDefault].forEach((gql, i) => {
+  describe(`gql ${i}`, () => {
+    it("is correct for a simple query", () => {
+      const ast = gql`
+        {
+          user(id: 5) {
+            firstName
+            lastName
+          }
+        }
+      `;
+
+      assert.equal(ast.kind, "Document");
+      assert.deepEqual(ast.definitions, [
+        {
+          kind: "OperationDefinition",
+          operation: "query",
+          name: null,
+          variableDefinitions: null,
+          directives: [],
+          selectionSet: {
+            kind: "SelectionSet",
+            selections: [
+              {
+                kind: "Field",
+                alias: null,
+                name: {
+                  kind: "Name",
+                  value: "user"
+                },
+                arguments: [
+                  {
+                    kind: "Argument",
+                    name: {
+                      kind: "Name",
+                      value: "id"
+                    },
+                    value: {
+                      kind: "IntValue",
+                      value: "5"
+                    }
+                  }
+                ],
+                directives: [],
+                selectionSet: {
+                  kind: "SelectionSet",
+                  selections: [
+                    {
+                      kind: "Field",
+                      alias: null,
+                      name: {
+                        kind: "Name",
+                        value: "firstName"
+                      },
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null
+                    },
+                    {
+                      kind: "Field",
+                      alias: null,
+                      name: {
+                        kind: "Name",
+                        value: "lastName"
+                      },
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]);
+    });
+    it("is correct for a fragment", () => {
+      const ast = gql`
+        fragment UserFragment on User {
+          firstName
+          lastName
+        }
+      `;
+
+      assert.equal(ast.kind, "Document");
+      assert.deepEqual(ast.definitions, [
+        {
+          kind: "FragmentDefinition",
+          name: {
+            kind: "Name",
+            value: "UserFragment"
+          },
+          typeCondition: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "User"
+            }
+          },
+          directives: [],
+          selectionSet: {
+            kind: "SelectionSet",
+            selections: [
+              {
+                kind: "Field",
+                alias: null,
+                name: {
+                  kind: "Name",
+                  value: "firstName"
+                },
+                arguments: [],
+                directives: [],
+                selectionSet: null
+              },
+              {
+                kind: "Field",
+                alias: null,
+                name: {
+                  kind: "Name",
+                  value: "lastName"
+                },
+                arguments: [],
+                directives: [],
+                selectionSet: null
+              }
+            ]
+          }
+        }
+      ]);
+    });
+  });
+});

--- a/test/graphql-v0.12.js
+++ b/test/graphql-v0.12.js
@@ -1,0 +1,138 @@
+const gqlRequire = require("../src");
+const gqlDefault = require("../src").default;
+const assert = require("chai").assert;
+
+[gqlRequire, gqlDefault].forEach((gql, i) => {
+  describe(`gql ${i}`, () => {
+    it("is correct for a simple query", () => {
+      const ast = gql`
+        {
+          user(id: 5) {
+            firstName
+            lastName
+          }
+        }
+      `;
+
+      assert.equal(ast.kind, "Document");
+      assert.deepEqual(ast.definitions, [
+        {
+          kind: "OperationDefinition",
+          operation: "query",
+          name: undefined,
+          variableDefinitions: [],
+          directives: [],
+          selectionSet: {
+            kind: "SelectionSet",
+            selections: [
+              {
+                kind: "Field",
+                alias: undefined,
+                name: {
+                  kind: "Name",
+                  value: "user"
+                },
+                arguments: [
+                  {
+                    kind: "Argument",
+                    name: {
+                      kind: "Name",
+                      value: "id"
+                    },
+                    value: {
+                      kind: "IntValue",
+                      value: "5"
+                    }
+                  }
+                ],
+                directives: [],
+                selectionSet: {
+                  kind: "SelectionSet",
+                  selections: [
+                    {
+                      kind: "Field",
+                      alias: undefined,
+                      name: {
+                        kind: "Name",
+                        value: "firstName"
+                      },
+                      arguments: [],
+                      directives: [],
+                      selectionSet: undefined
+                    },
+                    {
+                      kind: "Field",
+                      alias: undefined,
+                      name: {
+                        kind: "Name",
+                        value: "lastName"
+                      },
+                      arguments: [],
+                      directives: [],
+                      selectionSet: undefined
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]);
+    });
+
+    it("is correct for a fragment", () => {
+      const ast = gql`
+        fragment UserFragment on User {
+          firstName
+          lastName
+        }
+      `;
+
+      assert.equal(ast.kind, "Document");
+      assert.deepEqual(ast.definitions, [
+        {
+          kind: "FragmentDefinition",
+          name: {
+            kind: "Name",
+            value: "UserFragment"
+          },
+          typeCondition: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "User"
+            }
+          },
+          directives: [],
+          selectionSet: {
+            kind: "SelectionSet",
+            selections: [
+              {
+                kind: "Field",
+                alias: undefined,
+                name: {
+                  kind: "Name",
+                  value: "firstName"
+                },
+                arguments: [],
+                directives: [],
+                selectionSet: undefined
+              },
+              {
+                kind: "Field",
+                alias: undefined,
+                name: {
+                  kind: "Name",
+                  value: "lastName"
+                },
+                arguments: [],
+                directives: [],
+                selectionSet: undefined
+              }
+            ]
+          }
+        }
+      ]);
+    });
+  });
+});

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -1,6 +1,6 @@
-const gqlRequire = require('./src');
-const gqlDefault = require('./src').default;
-const loader = require('./loader');
+const gqlRequire = require('../src');
+const gqlDefault = require('../src').default;
+const loader = require('../loader');
 const assert = require('chai').assert;
 
 [gqlRequire, gqlDefault].forEach((gql, i) => {
@@ -227,169 +227,16 @@ const assert = require('chai').assert;
       assert.isTrue(gql`{ sameQuery }` === gql`  { sameQuery,   }`);
     });
 
-    it('is correct for a simple query', () => {
-      const ast = gql`
-        {
-          user(id: 5) {
-            firstName
-            lastName
-          }
-        }
-      `;
-
-      assert.equal(ast.kind, "Document");
-      assert.deepEqual(ast.definitions, [
-        {
-          "kind": "OperationDefinition",
-          "operation": "query",
-          "name": null,
-          "variableDefinitions": null,
-          "directives": [],
-          "selectionSet": {
-            "kind": "SelectionSet",
-            "selections": [
-              {
-                "kind": "Field",
-                "alias": null,
-                "name": {
-                  "kind": "Name",
-                  "value": "user"
-                },
-                "arguments": [
-                  {
-                    "kind": "Argument",
-                    "name": {
-                      "kind": "Name",
-                      "value": "id"
-                    },
-                    "value": {
-                      "kind": "IntValue",
-                      "value": "5"
-                    }
-                  }
-                ],
-                "directives": [],
-                "selectionSet": {
-                  "kind": "SelectionSet",
-                  "selections": [
-                    {
-                      "kind": "Field",
-                      "alias": null,
-                      "name": {
-                        "kind": "Name",
-                        "value": "firstName"
-                      },
-                      "arguments": [],
-                      "directives": [],
-                      "selectionSet": null
-                    },
-                    {
-                      "kind": "Field",
-                      "alias": null,
-                      "name": {
-                        "kind": "Name",
-                        "value": "lastName"
-                      },
-                      "arguments": [],
-                      "directives": [],
-                      "selectionSet": null
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ]);
-    });
+    const fragmentAst = gql`
+    fragment UserFragment on User {
+      firstName
+      lastName
+    }
+  `;
 
     it('returns the same object for the same fragment', () => {
       assert.isTrue(gql`fragment same on Same { sameQuery }` ===
         gql`fragment same on Same { sameQuery }`);
-    });
-
-    it('is correct for a fragment', () => {
-      const ast = gql`
-        fragment UserFragment on User {
-          firstName
-          lastName
-        }
-      `;
-
-      assert.equal(ast.kind, "Document");
-      assert.deepEqual(ast.definitions, [
-        {
-          "kind": "FragmentDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "UserFragment"
-          },
-          "typeCondition": {
-            kind: "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "User"
-            }
-          },
-          "directives": [],
-          "selectionSet": {
-            "kind": "SelectionSet",
-            "selections": [
-              {
-                "kind": "Field",
-                "alias": null,
-                "name": {
-                  "kind": "Name",
-                  "value": "firstName"
-                },
-                "arguments": [],
-                "directives": [],
-                "selectionSet": null
-              },
-              {
-                "kind": "Field",
-                "alias": null,
-                "name": {
-                  "kind": "Name",
-                  "value": "lastName"
-                },
-                "arguments": [],
-                "directives": [],
-                "selectionSet": null
-              }
-            ]
-          }
-        }
-      ]);
-    });
-
-    const fragmentAst = gql`
-      fragment UserFragment on User {
-        firstName
-        lastName
-      }
-    `;
-    it('can reference a fragment passed as a document', () => {
-      const ast = gql`
-        {
-          user(id: 5) {
-            ...UserFragment
-          }
-        }
-        ${fragmentAst}
-      `;
-
-      assert.deepEqual(ast, gql`
-        {
-          user(id: 5) {
-            ...UserFragment
-          }
-        }
-        fragment UserFragment on User {
-          firstName
-          lastName
-        }
-      `);
     });
 
     it('returns the same object for the same document with substitution', () => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require babel-register

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,7 +644,7 @@ globals@^9.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql@0.13:
+graphql@^0.13.0:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.1.tgz#9b3db3d8e40d1827e4172404bfdd2e4e17a58b55"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+acorn@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-0.9.0.tgz#67728e0acad6cc61dfb901c121837694db5b926b"
+
+after-all-results@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/after-all-results/-/after-all-results-2.0.0.tgz#6ac2fc202b500f88da8f4f5530cfa100f4c6a2d0"
+
+ansi-diff-stream@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-diff-stream/-/ansi-diff-stream-1.2.0.tgz#eb325c20ac3623ecd592011a9295d76d97de460e"
+  dependencies:
+    ansi-regex "^2.0.0"
+    through2 "^2.0.1"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -10,9 +25,27 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
 assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
+astw@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/astw/-/astw-1.3.0.tgz#015774a6427ad3b9ec46d7a2b41ae73dac624ca5"
+  dependencies:
+    esprima "^2.1.0"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -448,9 +481,35 @@ chalk@^1.1.0:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
+cli-spinners@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.1.0.tgz#f1847b168844d917a671eb9d147e3df497c90d06"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 commander@2.9.0:
   version "2.9.0"
@@ -470,6 +529,16 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
+core-util-is@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+dargs@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
+  dependencies:
+    number-is-nan "^1.0.0"
+
 debug@2.6.0, debug@^2.1.1, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
@@ -482,6 +551,10 @@ deep-eql@^2.0.1:
   dependencies:
     type-detect "^3.0.0"
 
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -492,13 +565,57 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escodegen@^1.4.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.5.6"
+
+esprima@^2.1.0:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fresh-require@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fresh-require/-/fresh-require-1.0.3.tgz#5a0613c023a2b0dce4373864ba539bade45122c3"
+  dependencies:
+    acorn "^0.9.0"
+    astw "^1.2.0"
+    escodegen "^1.4.1"
+    is-require "0.0.1"
+    resolve "^1.0.0"
+    shallow-copy "0.0.1"
+    sleuth "^0.1.1"
+    through2 "^0.6.3"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -527,11 +644,11 @@ globals@^9.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.0.tgz#29e4f83d85e79245f8496f40a2232e6e5c5baaee"
+graphql@0.13:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.1.tgz#9b3db3d8e40d1827e4172404bfdd2e4e17a58b55"
   dependencies:
-    iterall "^1.1.0"
+    iterall "^1.2.0"
 
 growl@1.9.2:
   version "1.9.2"
@@ -547,6 +664,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -561,7 +682,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -571,19 +692,44 @@ invariant@^2.2.0:
   dependencies:
     loose-envify "^1.0.0"
 
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
   dependencies:
     number-is-nan "^1.0.0"
 
-iterall@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
+is-require@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/is-require/-/is-require-0.0.1.tgz#0d1e6d93e380b35386f474543fffc9a66d41825e"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+iterall@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.0.tgz#434e9f41f0b99911ab9c3d49d95f0e079176a2a2"
 
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+js-yaml@^3.7.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -600,6 +746,13 @@ json3@3.3.2:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"
@@ -652,6 +805,12 @@ lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
 loose-envify@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -667,6 +826,10 @@ minimatch@^3.0.2:
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 mkdirp@0.5.1, mkdirp@^0.5.1:
   version "0.5.1"
@@ -694,15 +857,30 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+npm-package-versions@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-package-versions/-/npm-package-versions-1.0.1.tgz#76369335c3be7e95e52d4dc8009bda31db458d3d"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+optionator@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -716,13 +894,46 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+"readable-stream@>=1.0.33-1 <1.1.0-0":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^2.1.5:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -764,15 +975,40 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-rollup@^0.42.0:
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.42.0.tgz#56e791b3a2f3dd7190bbb80a375675f2fe0f9b23"
+resolve@^1.0.0, resolve@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
+rollup@^0.45.0:
+  version "0.45.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.45.2.tgz#63a284c2b31234656f24e9e9717fabb6a7f0fa43"
   dependencies:
     source-map-support "^0.4.0"
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+semver@^5.1.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+shallow-copy@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
 
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+sleuth@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sleuth/-/sleuth-0.1.1.tgz#406efb86730ba5c27147b570186d72c83b0d8cc0"
+  dependencies:
+    is-require "0.0.1"
+    static-eval "~0.1.0"
 
 source-map-support@^0.4.0, source-map-support@^0.4.2:
   version "0.4.14"
@@ -783,6 +1019,34 @@ source-map-support@^0.4.0, source-map-support@^0.4.2:
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+spawn-npm-install@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/spawn-npm-install/-/spawn-npm-install-1.2.0.tgz#da04c7c87b3f6ab4f49605d8bf5178bed249121f"
+  dependencies:
+    dargs "^4.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+static-eval@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-0.1.1.tgz#2f3c9e727604a61ac761b9663562a76c61f5c523"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -800,6 +1064,44 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+test-all-versions@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/test-all-versions/-/test-all-versions-3.3.2.tgz#ab0dd7f71cc8aeb8a31465cda68afb2f0f53ae62"
+  dependencies:
+    after-all-results "^2.0.0"
+    ansi-diff-stream "^1.2.0"
+    cli-spinners "^1.1.0"
+    fresh-require "^1.0.3"
+    is-ci "^1.0.10"
+    js-yaml "^3.7.0"
+    log-symbols "^2.1.0"
+    minimist "^1.2.0"
+    npm-package-versions "^1.0.1"
+    once "^1.4.0"
+    resolve "^1.2.0"
+    semver "^5.1.0"
+    spawn-npm-install "^1.2.0"
+
+through2@^0.6.3:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
+through2@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
+
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
@@ -807,6 +1109,12 @@ to-fast-properties@^1.0.1:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-detect@^3.0.0:
   version "3.0.0"
@@ -816,6 +1124,18 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+"xtend@>=4.0.0 <4.1.0-0", xtend@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
As new versions of `graphql` get released, its hard to figure out whether or not we're honoring our `peerDependencies` and actually supporting all versions of `graphql`. [test-all-versions](https://github.com/watson/test-all-versions) allows us to configure our compatibility matrix and run them on every PR to ensure that we know when we're making backwards-incompatible changes.

The test files here are split because while the functionality of `graphql-tag` does not differ between versions, the output of one of the packages we depend on _does_ differ. I'm capturing that difference by splitting the tests and confirming that, yes, we do support both versions. In the future, if a PR were to break one or both of the tests, we could then determine that we need to put through a major version change and also change our compatibility matrix. I wish there was a better way to capture the difference in output besides duplicating the tests.