### PR TITLE
Added experimentalFragmentVariables compatibility.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ function parseDocument(doc) {
     return docCache[cacheKey];
   }
 
-  var parsed = parse(doc, { experimentalFragmentVariables });
+  var parsed = parse(doc, { experimentalFragmentVariables: experimentalFragmentVariables });
   if (!parsed || parsed.kind !== 'Document') {
     throw new Error('Not a valid GraphQL document.');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ function stripLoc(doc, removeLocAtThisLevel) {
   return doc;
 }
 
+var experimentalFragmentVariables = false;
 function parseDocument(doc) {
   var cacheKey = normalize(doc);
 
@@ -125,7 +126,7 @@ function parseDocument(doc) {
     return docCache[cacheKey];
   }
 
-  var parsed = parse(doc);
+  var parsed = parse(doc, { experimentalFragmentVariables });
   if (!parsed || parsed.kind !== 'Document') {
     throw new Error('Not a valid GraphQL document.');
   }
@@ -137,6 +138,14 @@ function parseDocument(doc) {
   docCache[cacheKey] = parsed;
 
   return parsed;
+}
+
+function enableExperimentalFragmentVariables() {
+  experimentalFragmentVariables = true;
+}
+
+function disableExperimentalFragmentVariables() {
+  experimentalFragmentVariables = false;
 }
 
 // XXX This should eventually disallow arbitrary string interpolation, like Relay does
@@ -165,5 +174,7 @@ function gql(/* arguments */) {
 gql.default = gql;
 gql.resetCaches = resetCaches;
 gql.disableFragmentWarnings = disableFragmentWarnings;
+gql.enableExperimentalFragmentVariables = enableExperimentalFragmentVariables;
+gql.disableExperimentalFragmentVariables = disableExperimentalFragmentVariables;
 
 module.exports = gql;

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -83,6 +83,16 @@ const assert = require('chai').assert;
       assert.equal(module.exports.Q2.definitions.length, 1);
     });
 
+    it('parses fragments with variable definitions', () => {
+      gql.enableExperimentalFragmentVariables()
+
+      const parsed = gql`fragment A ($arg: String!) on Type { testQuery }`;
+      assert.equal(parsed.kind, 'Document');
+      assert.exists(parsed.definitions[0].variableDefinitions)
+
+      gql.disableExperimentalFragmentVariables()
+    })
+
     it('tracks fragment dependencies from multiple queries through webpack loader', () => {
       const jsSource = loader.call({ cacheable() {} }, `
         fragment F1 on F { testQuery }


### PR DESCRIPTION
I'm experimenting with fragments on [react-apollo-fragments](http://github.com/lucasconstantino/react-apollo-fragments) and have reached a point to deal with fragment variables. The folks at the core of *graphql-js* project have added some experimental parsing for this, and I would love to use it in my own library. But as I use `graphql-tag`, as as this library does not export the full parser API below it, I'm decided to pull-request.

You can better understand what I'm looking for here https://github.com/graphql/graphql-js/blob/master/src/language/parser.js#L99-L115

I tried to find a workaround, but I found no way other than replace *graphql-tag* usage.

- [x] feature
- [ ] blocking
- [ ] docs