### PR TITLE
Fix duplicate queries in named exports

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -153,6 +153,12 @@ module.exports = function(source) {
     module.exports = doc;
     `
 
+    // Make copy before named exports are added to the doc
+    // see https://github.com/apollographql/graphql-tag/issues/168
+    outputCode += `
+    var docCopy = Object.assign({}, doc);
+    `
+
     for (const op of doc.definitions) {
       if (op.kind === "OperationDefinition") {
         if (!op.name) {
@@ -165,7 +171,7 @@ module.exports = function(source) {
 
         const opName = op.name.value;
         outputCode += `
-        module.exports["${opName}"] = oneQuery(doc, "${opName}");
+        module.exports["${opName}"] = oneQuery(docCopy, "${opName}");
         `
       }
     }

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -83,6 +83,21 @@ const assert = require('chai').assert;
       assert.equal(module.exports.Q2.definitions.length, 1);
     });
 
+    // see https://github.com/apollographql/graphql-tag/issues/168
+    it('does not nest queries needlessly in named exports', () => {
+      const jsSource = loader.call({ cacheable() {} }, `
+        query Q1 { testQuery }
+        query Q2 { testQuery2 }
+        query Q3 { test Query3 }
+      `);
+      const module = { exports: undefined };
+      eval(jsSource);
+
+      assert.notExists(module.exports.Q2.Q1);
+      assert.notExists(module.exports.Q3.Q1);
+      assert.notExists(module.exports.Q3.Q2);
+    });
+
     it('tracks fragment dependencies from multiple queries through webpack loader', () => {
       const jsSource = loader.call({ cacheable() {} }, `
         fragment F1 on F { testQuery }


### PR DESCRIPTION
Recent changes to the loader exported queries as individual named exports, but each such export erroneously included the previous exports. This gets big fast.

Closes #168 