### PR TITLE
Expose AST transformer to support more bundlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,26 @@ fragment SomeFragment ($arg: String!) on SomeType {
 }
 ```
 
+### Other bundlers with `graphql-tag/loader`
 
+To create a custom loader for other bundlers, just import `transform` function. See below a [rollup](https://rollupjs.org/guide/en) plugin example:
+
+```js
+import { transform } from 'graphql-tag/loader';
+import { createFilter } from 'rollup-pluginutils';
+import { extname } from 'path';
+
+export default function GraphQLPlugin( options = {} ) {
+  var filter = createFilter( options.include, options.exclude );
+
+  return {
+    transform ( code, id ) {
+      if (!filter(id) || /\.(graphql|gql)$/.test(extname)) return;
+
+      return {
+        code: transform(code)
+      };
+    }
+  };
+}
+```

--- a/loader.js
+++ b/loader.js
@@ -39,8 +39,7 @@ function expandImports(source, doc) {
   return outputCode;
 }
 
-module.exports = function(source) {
-  this.cacheable();
+function transform(source) {
   const doc = gql`${source}`;
   let headerCode = `
     var doc = ${JSON.stringify(doc)};
@@ -52,7 +51,7 @@ module.exports = function(source) {
   // Allow multiple query/mutation definitions in a file. This parses out dependencies
   // at compile time, and then uses those at load time to create minimal query documents
   // We cannot do the latter at compile time due to how the #import code works.
-  let operationCount = doc.definitions.reduce(function(accum, op) {
+  let operationCount = doc.definitions.reduce(function (accum, op) {
     if (op.kind === "OperationDefinition") {
       return accum + 1;
     }
@@ -178,4 +177,14 @@ module.exports = function(source) {
   const allCode = headerCode + os.EOL + importOutputCode + os.EOL + outputCode + os.EOL;
 
   return allCode;
+}
+
+// make graphql transformer available for other bundlers
+exports.transform = transform;
+
+// webpack loader 
+module.exports = function(source) {
+  this.cacheable();
+
+  return transform(source);
 };


### PR DESCRIPTION
**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [x] docs

Currently `graphql-tag` loader only supports webpack. This PR exposes a function called `transform` in order to bring better compatibility with other tools.

Possible integrations after that:

- Parcel bundler: https://github.com/parcel-bundler/parcel/blob/master/src/assets/GraphqlAsset.js#L17
- Rollup: https://github.com/rollup/rollup/wiki/Plugins#creating-plugins
- Brownserify: https://github.com/browserify/browserify-handbook#writing-your-own
- Even Require.js for vintage projects


