### PR TITLE
Fix IE11 support

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -108,9 +108,12 @@ module.exports = function(source) {
     })();
 
     function findOperation(doc, name) {
-      return doc.definitions.find(function(op) {
-        return op.name ? op.name.value == name : false;
-      });
+      for (var i = 0; i < doc.definitions.length; i++) {
+        var element = doc.definitions[i];
+        if (element.name && element.name.value == name) {
+          return element;
+        }
+      }
     }
 
     function oneQuery(doc, operationName) {


### PR DESCRIPTION
Fixes #158.

Use a regular for-loop instead of `Array.prototype.find` so the code generated by the loader doesn't break in IE11.