### PR TITLE
Update deprecated package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Try this custom transformer to pre-compile your GraphQL queries in TypeScript: [
 
 #### React Native, Next.js
 
-Additionally, in certain situations, preprocessing queries via the webpack loader is not possible. [babel-plugin-inline-import-graphql-ast](https://www.npmjs.com/package/babel-plugin-inline-import-graphql-ast) will allow one to import graphql files directly into your JavaScript by preprocessing GraphQL queries into ASTs at compile-time.
+Additionally, in certain situations, preprocessing queries via the webpack loader is not possible. [babel-plugin-import-graphql](https://www.npmjs.com/package/babel-plugin-import-graphql) will allow one to import graphql files directly into your JavaScript by preprocessing GraphQL queries into ASTs at compile-time.
 
 E.g.:
 ```javascript
@@ -162,5 +162,3 @@ fragment SomeFragment ($arg: String!) on SomeType {
   someField
 }
 ```
-
-


### PR DESCRIPTION
I'm doing an official release of my package soon and in preparation for that, I changed the name because I didn't like it. I've updated the references and links in the README with the new name and URLs.

The old package and repo will remain available but users will get a deprecation warning when installing it asking them to switch to `babel-plugin-import-graphql`.
**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
