### PR TITLE
Add `yarn.lock`, `.editorconfig`, and `.flowconfig` to `.npmignore`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 .gitignore
 .babelrc
+.editorconfig
+.flowconfig
 .travis.yml
 test.js
 CHANGELOG.md

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 test.js
 CHANGELOG.md
 rollup.config.js
+yarn.lock


### PR DESCRIPTION
Alternatively, you could use the `files` field in `package.json` to whitelist the stuff you do want to push to NPM.