### PR TITLE
failing test for bad doc cache normalization

### DIFF
--- a/test/graphql.js
+++ b/test/graphql.js
@@ -275,6 +275,10 @@ const assert = require('chai').assert;
       assert.isTrue(gql`{ sameQuery }` === gql`  { sameQuery,   }`);
     });
 
+    it('returns a different object for the queries with significant whitespace differences', () => {
+      assert.isFalse(gql`{ sameQuery(f: "    ") }` === gql`  { sameQuery(f: " ") }`);
+    });
+
     const fragmentAst = gql`
     fragment UserFragment on User {
       firstName


### PR DESCRIPTION
graphql-tag has a cache to make multiple `gql` calls with roughly the same text return the same AST. However, the cache key normalization is too sensitive as it makes literal strings with different amount of whitespace equal.  This PR adds a failing test; I don't have time to actually fix the issue.

apollo-engine-reporting's signature.ts file has some building blocks for doing GraphQL signature transformations, though they are built on top of ASTs so they won't work well for this particular context.