### PR TITLE
Fix operations with fragments in the Webpack loader for IE 11

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -130,7 +130,13 @@ module.exports = function(source) {
       // it or the fragments it references
       var opRefs = definitionRefs[operationName] || new Set();
       var allRefs = new Set();
-      var newRefs = new Set(opRefs);
+      var newRefs = new Set();
+
+      // IE 11 doesn't support "new Set(iterable)", so we add the members of opRefs to newRefs one by one
+      opRefs.forEach(function(refName) {
+        newRefs.add(refName);
+      });
+
       while (newRefs.size > 0) {
         var prevRefs = newRefs;
         newRefs = new Set();


### PR DESCRIPTION
**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->

/label bug

I was using version 2.9.2 with the Webpack loader. On IE 11, I saw the following error:

    Fragment was XXX used, but not defined

It turns out that on line 133 of loader.js, we have `var newRefs = new Set(opRefs);` and [IE 11 doesn't support "new Set(iterable)"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set), so I rewrite it to add the members of opRefs to newRefs one by one using `forEach`, which resovles the issue.
