### PR TITLE
Ignore duplicate interfaces from imports when using webpack loader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -13,7 +13,7 @@ function expandImports(source, doc) {
     function unique(defs) {
       return defs.filter(
         function(def) {
-          if (def.kind !== 'FragmentDefinition') return true;
+          if (def.kind !== 'FragmentDefinition' && def.kind !== 'InterfaceTypeDefinition') return true;
           var name = def.name.value
           if (names[name]) {
             return false;


### PR DESCRIPTION
Fixes https://github.com/apollographql/graphql-tag/issues/194