### PR TITLE
Revert "Add DocumentNode to gql declaration (#196)"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import { DocumentNode } from 'graphql';
-
-export default function gql(literals: any, ...placeholders: any[]): DocumentNode;
+export default function gql(literals: any, ...placeholders: any[]): any;
 export function resetCaches(): void;
 export function disableFragmentWarnings(): void;


### PR DESCRIPTION
This reverts commit ae792b67ef16ae23a0a7a8d78af8b698e8acd7d2. Based on #196 and #150, introducing the `DocumentNode` return value causes this library to break for existing TypeScript installations. I'm reverting this temporarily so we can release support for GraphQL v14 in a minor patch, and if we can't fix the TypeScript configuration, we'll release a major version with this commit back in.

/cc @felixfbecker @kamilkisiela since i still can't figure out how to fix the TypeScript installation in a non-breaking way.