### PR TITLE
Add support for inline/shorthand fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,29 +138,6 @@ import { MyQuery1, MyQuery2 } from 'query.gql'
 ```
 
 #### Support for inline/shorthand fragments
-Instead of **Example A** you can do **Example B**:
-
-**Example A (old)**:
-```js
-const userFragmentDocument = gql`
-  fragment UserFragment on User {
-    firstName
-    lastName
-  }
-`
-      
-const ast = gql`
-  {
-    user(id: 5) {
-      ...UserFragment
-    }
-  }
-
-  ${userFragmentDocument}
-`;
-```
-
-**Example B (with inline/shorthand fragments)**:
 ```js
 const userFragmentDocument = gql`
   fragment UserFragment on User {

--- a/README.md
+++ b/README.md
@@ -137,6 +137,47 @@ And in your JavaScript:
 import { MyQuery1, MyQuery2 } from 'query.gql'
 ```
 
+#### Support for inline/shorthand fragments
+Instead of **Example A** you can do **Example B**:
+
+**Example A (old)**:
+```js
+const userFragmentDocument = gql`
+  fragment UserFragment on User {
+    firstName
+    lastName
+  }
+`
+      
+const ast = gql`
+  {
+    user(id: 5) {
+      ...UserFragment
+    }
+  }
+
+  ${userFragmentDocument}
+`;
+```
+
+**Example B (with inline/shorthand fragments)**:
+```js
+const userFragmentDocument = gql`
+  fragment UserFragment on User {
+    firstName
+    lastName
+  }
+`
+      
+const ast = gql`
+  {
+    user(id: 5) {
+      ...${userFragmentDocument}
+    }
+  }
+`;
+```
+
 ### Warnings
 
 This package will emit a warning if you have multiple fragments of the same name. You can disable this with:

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -438,28 +438,34 @@ const assert = require('chai').assert;
       });
     });
 
-    // How to make this work?
-    // it.only('can reference a fragment passed as a document via shorthand', () => {
-    //   const ast = gql`
-    //     {
-    //       user(id: 5) {
-    //         ...${userFragmentDocument}
-    //       }
-    //     }
-    //   `;
-    //
-    //   assert.deepEqual(ast, gql`
-    //     {
-    //       user(id: 5) {
-    //         ...UserFragment
-    //       }
-    //     }
-    //     fragment UserFragment on User {
-    //       firstName
-    //       lastName
-    //     }
-    //   `);
-    // });
+    it('can reference a fragment passed as a document via shorthand', () => {
+      const userFragmentDocument = gql`
+        fragment UserFragment on User {
+          firstName
+          lastName
+        }
+      `
+      
+      const ast = gql`
+        {
+          user(id: 5) {
+            ...${userFragmentDocument}
+          }
+        }
+      `;
+    
+      assert.deepEqual(ast, gql`
+        {
+          user(id: 5) {
+            ...UserFragment
+          }
+        }
+        fragment UserFragment on User {
+          firstName
+          lastName
+        }
+      `);
+    });
 
   });
 });


### PR DESCRIPTION
**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this pull request when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

This PR adds support for inline or shorthand fragment definitions: 

# Old
```js
const userFragmentDocument = gql`
  fragment UserFragment on User {
    firstName
    lastName
  }
`
      
const ast = gql`
  {
    user(id: 5) {
      ...UserFragment
    }
  }

  ${userFragmentDocument}
`;
```

# New

```js
const userFragmentDocument = gql`
  fragment UserFragment on User {
    firstName
    lastName
  }
`
      
const ast = gql`
  {
    user(id: 5) {
      ...${userFragmentDocument}
    }
  }
`;
```

# Motivation
> Note that I have to include the fragment in two different places by two different names. Combined with the fact that fragments are usually in different files, this adds quite a bit of unnecessary friction and uncertainty to referencing a fragment. - @dallonf

Also special thanks to @jonaskello for his helpful [comment](https://github.com/apollographql/graphql-tag/issues/84#issuecomment-374147891) and @tmeasday for [adding the tests 2 years ago](https://github.com/apollographql/graphql-tag/commit/6aa3fbf44b4d21bf3de65cdc03df9bbede963f84#diff-1dd241c4cd3fd1dd89c570cee98b79ddR183) 😄 

Fixes #84 