### PR TITLE
Added support for nested fragments when importing from graphql/loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 var parser = require('graphql/language/parser');
-
+var printer = require('graphql/language/printer');
 var parse = parser.parse;
+var print = printer.print;
 
 // Strip insignificant whitespace
 // Note that this could do a lot more, such as reorder fields etc.
@@ -159,7 +160,7 @@ function gql(/* arguments */) {
 
   for (var i = 1; i < args.length; i++) {
     if (args[i] && args[i].kind && args[i].kind === 'Document') {
-      result += args[i].loc.source.body;
+      result += print(args[i]);
     } else {
       result += args[i];
     }


### PR DESCRIPTION
Used test from [https://github.com/apollographql/graphql-tag/pull/105](https://github.com/apollographql/graphql-tag/pull/105)

Simplified import of nested fragments - uses the built-in graphql printer to get the full source including any nested fragments

Fixes the following situation:

**AuthorDetailsFragment.gql**

```
fragment AuthorDetails on Author {
    firstName
    lastName
}
```


**BookDetailsFragment.gql**

```
#import "./AuthorDetailsFragment.gql"
fragment BooksAuthor on Book {
    author {
        ...AuthorDetails
    }
}
```

**main.js**
```
import gql from 'graphql-tag';
import BookDetails from './BookDetailsFragment.gql';

const result = gql`query { ...BooksAuthor } ${BookDetails}`;
```

Previously, result would only include 2 definitions: the Query and the BooksAuthor fragment - and ignore the AuthorDetails fragment.

Now result should include all 3