### PR TITLE
chore: add type for experimentalFragmentVariables

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
 export default function gql(literals: any, ...placeholders: any[]): any;
 export function resetCaches(): void;
 export function disableFragmentWarnings(): void;
+export function enableExperimentalFragmentVariables(): void;
+export function disableExperimentalFragmentVariables(): void;


### PR DESCRIPTION
I found https://github.com/apollographql/graphql-tag/pull/167 but the TS definitions of `enableExperimentalFragmentVariables` and `disableExperimentalFragmentVariables` was not found.