### PR TITLE
Updated CRA2 preprocess ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class ProductsPage extends React.Component {
 
 #### Create-React-App
 
-`create-react-app@2.0.0` will [support the ability to preprocess queries](https://github.com/facebook/create-react-app/pull/3909) using `graphql-tag/loader` without the need to eject.
+`create-react-app@2.0.0` does support the ability to preprocess queries using [evenchange4/graphql.macro](https://github.com/evenchange4/graphql.macro).
 
 If you're using an older version of `create-react-app`, check out [react-app-rewire-inline-import-graphql-ast](https://www.npmjs.com/package/react-app-rewire-inline-import-graphql-ast) to preprocess queries without needing to eject.
 


### PR DESCRIPTION
Initial loader support in CRA2 was reverted here: https://github.com/facebook/create-react-app/pull/5076
Using the macro https://github.com/evenchange4/graphql.macro the same can be achieved.