### PR TITLE
chore: provide CJS and ESM bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "./src/index.js",
   "scripts": {
     "bundle": "rollup -c",
-    "copy-types": "cp src/index.js.flow lib/graphql-tag.esm.js.flow && cp src/index.js.flow lib/graphql-tag.cjs.js.flow",
+    "copy-types": "cp src/index.js.flow lib/graphql-tag.umd.js.flow && cp src/index.js.flow lib/graphql-tag.esm.js.flow && cp src/index.js.flow lib/graphql-tag.cjs.js.flow",
     "test": "mocha test/graphql.js test/graphql-v0.12.js && tav --ci --compat",
     "prepublish": "npm run bundle && npm run copy-types"
   },

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "graphql-tag",
   "version": "2.10.0",
   "description": "A JavaScript template literal tag that parses GraphQL queries",
-  "main": "./lib/graphql-tag.umd.js",
-  "module": "./src/index.js",
+  "browser": "./lib/graphql-tag.umd.js",
+  "main": "./lib/graphql-tag.cjs.js",
+  "module": "./lib/graphql-tag.esm.js",
   "jsnext:main": "./src/index.js",
   "scripts": {
-    "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
+    "bundle": "rollup -c",
+    "copy-types": "cp src/index.js.flow lib/graphql-tag.esm.js.flow && cp src/index.js.flow lib/graphql-tag.cjs.js.flow",
     "test": "mocha test/graphql.js test/graphql-v0.12.js && tav --ci --compat",
-    "prepublish": "npm run bundle"
+    "prepublish": "npm run bundle && npm run copy-types"
   },
   "repository": {
     "type": "git",
@@ -25,6 +27,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "chai": "^4.0.2",
+    "cross-env": "^5.2.0",
     "graphql": "^14.0.2",
     "mocha": "^3.4.1",
     "rollup": "^0.45.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "chai": "^4.0.2",
-    "cross-env": "^5.2.0",
     "graphql": "^14.0.2",
     "mocha": "^3.4.1",
     "rollup": "^0.45.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,35 @@
-export default {
-  entry: 'src/index.js',
-  dest: 'lib/graphql-tag.umd.js',
-  format: 'umd',
-  sourceMap: true,
-  moduleName: 'graphql-tag',
-  onwarn
-};
+function umd(input, output) {
+  return {
+    entry: input,
+    dest: output,
+    format: 'umd',
+    sourceMap: true,
+    moduleName: 'graphql-tag',
+    onwarn
+  }
+}
+
+function cjs(input, output) {
+  return {
+    entry: input,
+    dest: output,
+    format: 'cjs',
+    sourceMap: true,
+    moduleName: 'graphql-tag',
+    onwarn
+  }
+}
+
+function esm(input, output) {
+  return {
+    entry: input,
+    dest: output,
+    format: 'es',
+    sourceMap: true,
+    moduleName: 'graphql-tag',
+    onwarn
+  }
+}
 
 function onwarn(message) {
   const suppressed = [
@@ -17,3 +41,9 @@ function onwarn(message) {
     return console.warn(message.message);
   }
 }
+
+export default [
+  esm('src/index.js', 'lib/graphql-tag.esm.js'),
+  umd('src/index.js', 'lib/graphql-tag.umd.js'),
+  cjs('src/index.js', 'lib/graphql-tag.cjs.js'),
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,6 @@ function cjs(input, output) {
     dest: output,
     format: 'cjs',
     sourceMap: true,
-    moduleName: 'graphql-tag',
     onwarn
   }
 }
@@ -26,7 +25,6 @@ function esm(input, output) {
     dest: output,
     format: 'es',
     sourceMap: true,
-    moduleName: 'graphql-tag',
     onwarn
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,6 +533,23 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 dargs@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -708,6 +725,10 @@ is-require@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/is-require/-/is-require-0.0.1.tgz#0d1e6d93e380b35386f474543fffc9a66d41825e"
 
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -715,6 +736,10 @@ isarray@0.0.1:
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 iterall@^1.2.2:
   version "1.2.2"
@@ -857,6 +882,10 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
 npm-package-versions@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/npm-package-versions/-/npm-package-versions-1.0.1.tgz#76369335c3be7e95e52d4dc8009bda31db458d3d"
@@ -893,6 +922,10 @@ os-tmpdir@^1.0.1:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -995,9 +1028,23 @@ semver@^5.1.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
+semver@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
 shallow-copy@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -1127,6 +1174,12 @@ type-detect@^4.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
 
 wordwrap@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,23 +533,6 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-env@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
-  dependencies:
-    cross-spawn "^6.0.5"
-    is-windows "^1.0.0"
-
-cross-spawn@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
 dargs@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -725,10 +708,6 @@ is-require@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/is-require/-/is-require-0.0.1.tgz#0d1e6d93e380b35386f474543fffc9a66d41825e"
 
-is-windows@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -736,10 +715,6 @@ isarray@0.0.1:
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 iterall@^1.2.2:
   version "1.2.2"
@@ -882,10 +857,6 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-nice-try@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
-
 npm-package-versions@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/npm-package-versions/-/npm-package-versions-1.0.1.tgz#76369335c3be7e95e52d4dc8009bda31db458d3d"
@@ -922,10 +893,6 @@ os-tmpdir@^1.0.1:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-
-path-key@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -1028,23 +995,9 @@ semver@^5.1.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-semver@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-
 shallow-copy@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
-
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  dependencies:
-    shebang-regex "^1.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -1174,12 +1127,6 @@ type-detect@^4.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-which@^1.2.9:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  dependencies:
-    isexe "^2.0.0"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR allows us to follow the mainstream way of publishing a library, giving us the ability to provide a tree-shakeable esm bundle, a cjs bundle for main and an umd bundle for browser.

As mentioned in: https://github.com/apollographql/graphql-tag/issues/229
And as done in other repositories from apollo:
- https://github.com/apollographql/react-apollo/pull/2677
- https://github.com/apollographql/apollo-client/pull/4261

I also think it's quite safe to say that it would be appropriate to upgrade the rollup and babel deps, if this is desired I feel up to the task. Just reply it here

