### PR TITLE
Adding support for spreading fragments, in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Helpful utilities for parsing GraphQL queries. Includes:
 
 ### gql
 
-The `gql` template literal tag can be used to concisely write a GraphQL query that is parsed into the standard GraphQL AST:
+The `gql` template literal tag can be used to concisely write a GraphQL query that is parsed into the standard GraphQL AST. It is the recommended method for passing queries to [Apollo Client](https://github.com/apollographql/apollo-client). While it is primaryily build for the Apollo client, it generates generic graphQL AST which could, potentially be used by any graphQL client.
 
 ```js
 import gql from 'graphql-tag';
@@ -91,10 +91,6 @@ const query = gql`
 `
 ```
 
-You can easily explore GraphQL ASTs on [astexplorer.net](https://astexplorer.net/#/drYr8X1rnP/1).
-
-This package is the way to pass queries into [Apollo Client](https://github.com/apollographql/apollo-client). If you're building a GraphQL client, you can use it too!
-
 #### Why use this?
 
 GraphQL strings are the right way to write queries in your code, because they can be statically analyzed using tools like [eslint-plugin-graphql](https://github.com/apollographql/eslint-plugin-graphql). However, strings are inconvenient to manipulate, if you are trying to do things like add extra fields, merge multiple queries together, or other interesting stuff.
@@ -105,64 +101,29 @@ That's where this package comes in - it lets you write your queries with [ES2015
 
 This package only has one feature - it caches previous parse results in a simple dictionary. This means that if you call the tag on the same query multiple times, it doesn't waste time parsing it again. It also means you can use `===` to compare queries to check if they are identical.
 
-### Babel preprocessing
 
-GraphQL queries can be compiled at build time using [babel-plugin-graphql-tag](https://github.com/gajus/babel-plugin-graphql-tag). Pre-compiling queries decreases the script initialization time and reduces the bundle size by potentially removing the need for `graphql-tag` at runtime.
+### Importing graphQL files
 
-#### TypeScript
-Try this custom transformer to pre-compile your GraphQL queries in TypeScript: [ts-transform-graphql-tag](https://github.com/firede/ts-transform-graphql-tag).
+_To add support for importing `.graphql`/`.gql` files, see [Webpack loading and preprocessing](#webpack-loading-and-preprocessing) below._
 
-#### React Native, Next.js
+Given a file `MyQuery.graphql`
 
-Additionally, in certain situations, preprocessing queries via the webpack loader is not possible. [babel-plugin-import-graphql](https://www.npmjs.com/package/babel-plugin-import-graphql) will allow one to import graphql files directly into your JavaScript by preprocessing GraphQL queries into ASTs at compile-time.
-
-E.g.:
-```javascript
-import myImportedQuery from './productsQuery.graphql'
-
-class ProductsPage extends React.Component {
+```graphql
+query MyQuery {
   ...
 }
 ```
 
-#### Create-React-App
+If you have configured [the webpack graphql-tag/loader](#webpack-loading-and-preprocessing), you can import modules containing graphQL queries. The imported value will be the pre-built AST.
 
-`create-react-app@2.0.0` does support the ability to preprocess queries using [evenchange4/graphql.macro](https://github.com/evenchange4/graphql.macro).
-
-If you're using an older version of `create-react-app`, check out [react-app-rewire-inline-import-graphql-ast](https://www.npmjs.com/package/react-app-rewire-inline-import-graphql-ast) to preprocess queries without needing to eject.
-
-### Webpack preprocessing with `graphql-tag/loader`
-
-This package also includes a [webpack loader](https://webpack.js.org/concepts/loaders). There are many benefits over this approach, which saves GraphQL ASTs processing time on client-side and enable queries to be separated from script over `.graphql` files.
-
-```js
-loaders: [
-  {
-    test: /\.(graphql|gql)$/,
-    exclude: /node_modules/,
-    loader: 'graphql-tag/loader'
-  }
-]
+```graphql
+import MyQuery from 'query.graphql'
 ```
 
-then:
+#### Importing queries by name
 
-```js
-import query from './query.graphql';
+You can also import queriy and fragment documents by name.
 
-console.log(query);
-// {
-//   "kind": "Document",
-// ...
-```
-
-Testing environments that don't support Webpack require additional configuration. For [Jest](https://facebook.github.io/jest/) use [jest-transform-graphql](https://github.com/remind101/jest-transform-graphql).
-
-#### Support for multiple operations
-
-With the webpack loader, you can also import operations by name:
-
-In a file called `query.gql`:
 ```graphql
 query MyQuery1 {
   ...
@@ -175,8 +136,63 @@ query MyQuery2 {
 
 And in your JavaScript:
 ```javascript
-import { MyQuery1, MyQuery2 } from 'query.gql'
+import { MyQuery1, MyQuery2 } from 'query.graphql'
 ```
+
+### Preprocessing queries and fragments
+
+Preprocessing graphQL queries and fragments to ASTs at built time can greatly increase load times.
+
+#### Babel preprocessing
+
+GraphQL queries can be compiled at build time using [babel-plugin-graphql-tag](https://github.com/gajus/babel-plugin-graphql-tag). Pre-compiling queries decreases the script initialization time and reduces the bundle size by potentially removing the need for `graphql-tag` at runtime.
+
+#### TypeScript preprocessing
+Try this custom transformer to pre-compile your GraphQL queries in TypeScript: [ts-transform-graphql-tag](https://github.com/firede/ts-transform-graphql-tag).
+
+#### React Native and Next.js preprocessing
+
+Additionally, in certain situations, preprocessing queries via the webpack loader is not possible. [babel-plugin-import-graphql](https://www.npmjs.com/package/babel-plugin-import-graphql) will allow one to import graphql files directly into your JavaScript by preprocessing GraphQL queries into ASTs at compile-time.
+
+E.g.:
+```javascript
+import myImportedQuery from './productsQuery.graphql'
+
+class ProductsPage extends React.Component {
+  ...
+}
+```
+
+#### Webpack loading and preprocessing
+
+Using the included graphql-tag/loader it is possible to maintain query logic, separate from the rest of your applications logic. With the loader configured, imported graphQL files will be converted to AST during the webpack build process.
+
+_**Example webpack configuration**_
+
+```js
+{
+  ...
+  loaders: [
+    {
+      test: /\.(graphql|gql)$/,
+      exclude: /node_modules/,
+      loader: 'graphql-tag/loader'
+    }
+  ],
+  ...
+}
+```
+
+#### Create-React-App
+
+Preprocessing graphQL imports is supported in **create-react-app** v2 using [evenchange4/graphql.macro](https://github.com/evenchange4/graphql.macro).
+
+For versions **create-react-app** before v2, you'll either need to eject or use [react-app-rewire-inline-import-graphql-ast](https://www.npmjs.com/package/react-app-rewire-inline-import-graphql-ast).
+
+
+#### Testing
+
+Testing environments that don't support Webpack require additional configuration. For [Jest](https://facebook.github.io/jest/) use [jest-transform-graphql](https://github.com/remind101/jest-transform-graphql).
 
 ### Warnings
 
@@ -203,3 +219,7 @@ fragment SomeFragment ($arg: String!) on SomeType {
   someField
 }
 ```
+
+### Resources
+
+You can easily generate and explore GraphQL AST on [astexplorer.net](https://astexplorer.net/#/drYr8X1rnP/1).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Helpful utilities for parsing GraphQL queries. Includes:
 
 ### gql
 
-This is a template literal tag you can use to concisely write a GraphQL query that is parsed into the standard GraphQL AST:
+The `gql` template literal tag can be used to concisely write a GraphQL query that is parsed into the standard GraphQL AST:
 
 ```js
 import gql from 'graphql-tag';
@@ -25,29 +25,70 @@ const query = gql`
     }
   }
 `
+```
 
-// query is now a GraphQL syntax tree object
-console.log(query);
+The above query now contains the following syntax tree.
 
-// {
-//   "kind": "Document",
-//   "definitions": [
-//     {
-//       "kind": "OperationDefinition",
-//       "operation": "query",
-//       "name": null,
-//       "variableDefinitions": null,
-//       "directives": [],
-//       "selectionSet": {
-//         "kind": "SelectionSet",
-//         "selections": [
-//           {
-//             "kind": "Field",
-//             "alias": null,
-//             "name": {
-//               "kind": "Name",
-//               "value": "user",
-//               ...
+```json
+{
+  "kind": "Document",
+  "definitions": [
+    {
+      "kind": "OperationDefinition",
+      "operation": "query",
+      "name": null,
+      "variableDefinitions": null,
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "Field",
+            "alias": null,
+            "name": {
+              "kind": "Name",
+              "value": "user",
+              ...
+```
+
+#### Fragments
+
+The `gql` tag can also be used to define reusable fragments, which can easily be added to queries or other fragments.
+
+```js
+import gql from 'graphql-tag';
+
+const userFragment = gql`
+  fragment User_user on User {
+    firstName
+    lastName
+  }
+`
+```
+
+The above `userFragment` document can be "spread" into the selection set of another document, the `gql` tag will automatically append the fragment definition to the new document for you.
+
+```js
+const query = gql`
+  {
+    user(id: 5) {
+      ...${userFragment}
+    }
+  }
+`
+```
+
+Alternatively, you can manually include and use the fragment definition.
+
+```js
+const query = gql`
+  {
+    user(id: 5) {
+      ...User_user
+    }
+  }
+  ${userFragment}
+`
 ```
 
 You can easily explore GraphQL ASTs on [astexplorer.net](https://astexplorer.net/#/drYr8X1rnP/1).

--- a/src/index.js
+++ b/src/index.js
@@ -156,16 +156,23 @@ function gql(/* arguments */) {
 
   // We always get literals[0] and then matching post literals for each arg given
   var result = (typeof(literals) === "string") ? literals : literals[0];
+  var fragments = '';
 
   for (var i = 1; i < args.length; i++) {
     if (args[i] && args[i].kind && args[i].kind === 'Document') {
-      result += args[i].loc.source.body;
+      if (result.substring(result.length - 3) === '...') {
+        result += args[i].definitions[0].name.value
+        fragments += '\n' + args[i].loc.source.body
+      } else {
+        result += args[i].loc.source.body;
+      }
     } else {
       result += args[i];
     }
 
     result += literals[i];
   }
+  result += fragments;
 
   return parseDocument(result);
 }

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -92,7 +92,7 @@ const assert = require('chai').assert;
 
       gql.disableExperimentalFragmentVariables()
     });
-    
+
     // see https://github.com/apollographql/graphql-tag/issues/168
     it('does not nest queries needlessly in named exports', () => {
       const jsSource = loader.call({ cacheable() {} }, `
@@ -292,6 +292,28 @@ const assert = require('chai').assert;
       // the same document, so we can reuse `fragmentAst`
       assert.isTrue(gql`{ ...UserFragment } ${fragmentAst}` ===
         gql`{ ...UserFragment } ${fragmentAst}`);
+    });
+
+    it('can spread a fragment in place', () => {
+      const ast = gql`
+        {
+          user(id: 5) {
+            ...${fragmentAst}
+          }
+        }
+      `;
+
+      assert.deepEqual(ast, gql`
+        {
+          user(id: 5) {
+            ...UserFragment
+          }
+        }
+        fragment UserFragment on User {
+          firstName
+          lastName
+        }
+      `);
     });
 
     it('can reference a fragment that references as fragment', () => {


### PR DESCRIPTION
This change adds support for a simplified syntax for including externally defined fragments. As long as a consumer is ok with the fragment being added to the end of the query, they can include the fragment just where they want it, without knowing its name.

### New syntax

```js
const personFragment = gql`
    fragment Person_person on Person {
        firstName
        lastName
    }
`;
const query = gql`
    {
        user(id: 5) {
            # personFragment is added to the end of the document and replaced here with its name
            ...${personFragment}
        }
    }
`;
```

### The above code results in the following graphQL query

```graphql
{
  user(id: 5) {
    ...Person_person
  }
}
fragment Person_person on Person {
  firstName
  lastName
}
```

Closes #237