### PR TITLE
Don't require this.cacheable to be available in loader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -40,7 +40,7 @@ function expandImports(source, doc) {
 }
 
 module.exports = function(source) {
-  this.cacheable();
+  if(this.cacheable) this.cacheable();
   const doc = gql`${source}`;
   let headerCode = `
     var doc = ${JSON.stringify(doc)};


### PR DESCRIPTION
Allow the loader to be used outside of the webpack context more easily.