### PR TITLE
Fragments bodies where added multiple times (duplicates)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,9 @@ function gql(/* arguments */) {
 
   for (var i = 1; i < args.length; i++) {
     if (args[i] && args[i].kind && args[i].kind === 'Document') {
-      result += args[i].loc.source.body;
+      var body = args[i].loc.source.body;
+      // Dont add body's that where already added by other documents
+      if (result.indexOf(body) === -1) result += body;
     } else {
       result += args[i];
     }

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -327,6 +327,59 @@ const assert = require('chai').assert;
       `);
     });
 
+    it('can include fragments sources only once if they are nested and used multiple times', () => {
+      const fragmentB = gql`
+        fragment FragmentB on Other {
+          number
+        }
+      `;
+
+      const fragmentA = gql`
+        fragment FragmentA on Something {
+          value
+          other {
+            ...FragmentB
+          }
+        }
+        ${fragmentB}
+      `;
+
+      const ast = gql`
+        query Query {
+          a {
+            ...FragmentA
+          }
+          b {
+            ...FragmentB
+          }
+        }
+        ${fragmentA}
+        ${fragmentB}
+      `;
+
+      assert.deepEqual(ast, gql`
+        query Query {
+          a {
+            ...FragmentA
+          }          
+          b {
+            ...FragmentB
+          }
+        }
+
+        fragment FragmentA on Something {
+          value
+          other {
+            ...FragmentB
+          }
+        }
+
+        fragment FragmentB on Other {
+          number
+        }
+      `);
+    });
+
     describe('fragment warnings', () => {
       let warnings = [];
       const oldConsoleWarn = console.warn;


### PR DESCRIPTION
In scenarios where a fragment is nested and used multiple times graphql-tag includes the fragments bodies (source) multiple times. While its obviously wrong, our graphql server also rejecting that requests. 

### Scenario
```javascript
const FragmentB = gql`
  fragment FragmentB on Other {
    number
  }
`;

const FragmentA = gql`
  fragment FragmentA on Something {
    value
    other {
      ...FragmentB
    }
  }
  ${FragmentB}
`;

const Query = gql`
  query Query {
    a {
      ...FragmentA
    }
    b {
      ...FragmentB
    }
  }
  ${FragmentA}
  ${FragmentB}
`;
```

### Current output (v2.10.1 and before)
```graphql
  query Query {
    a {
      ...FragmentA
    }
    b {
      ...FragmentB
    }
  }

  fragment FragmentA on Something {
    value
    other {
      ...FragmentB
    }
  }

  fragment FragmentB on Other {
    number
  }



  fragment FragmentB on Other {
    number
  }

```
### Expected output (this Pullrequest)
```graphql
  query Query {
    a {
      ...FragmentA
    }
    b {
      ...FragmentB
    }
  }

  fragment FragmentA on Something {
    value
    other {
      ...FragmentB
    }
  }

  fragment FragmentB on Other {
    number
  }
```

I also added a test for this scenario. 