### PR TITLE
Add default export from graphql-tag/loader modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,12 @@ console.log(query);
 
 Testing environments that don't support Webpack require additional configuration. For [Jest](https://facebook.github.io/jest/) use [jest-transform-graphql](https://github.com/remind101/jest-transform-graphql).
 
-#### Support for multiple operations
+#### Support for multiple operations per file
 
-With the webpack loader, you can also import operations by name:
+With the webpack loader, the default export from a graphql file contains all the operations found in
+the original file.  Typically a GraphQL client library expects to find only one operation, so if
+you want to put multiple operations in the same file, you should import individual operations
+by name:
 
 In a file called `query.gql`:
 ```graphql
@@ -136,7 +139,7 @@ And in your JavaScript:
 ```javascript
 import { MyQuery1, MyQuery2 } from 'query.gql'
 ```
-
+ 
 ### Warnings
 
 This package will emit a warning if you have multiple fragments of the same name. You can disable this with:

--- a/loader.js
+++ b/loader.js
@@ -161,8 +161,8 @@ module.exports = function(source) {
 
       return newDoc;
     }
-
-    module.exports = doc;
+    
+    module.exports = Object.assign({default: doc}, doc);
     `
 
     for (const op of doc.definitions) {

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -65,6 +65,7 @@ const assert = require('chai').assert;
       eval(jsSource);
 
       assert.deepEqual(module.exports.definitions, module.exports.Q1.definitions);
+      assert.deepEqual(module.exports.default.definitions, module.exports.Q1.definitions);
     });
 
     it('parses multiple queries through webpack loader', () => {
@@ -81,6 +82,9 @@ const assert = require('chai').assert;
       assert.equal(module.exports.Q2.kind, 'Document');
       assert.equal(module.exports.Q1.definitions.length, 1);
       assert.equal(module.exports.Q2.definitions.length, 1);
+      assert.equal(module.exports.default.definitions.length, 2);
+      assert.equal(module.exports.default.definitions[0], module.exports.Q1.definitions[0]);
+      assert.equal(module.exports.default.definitions[1], module.exports.Q2.definitions[0]);
     });
 
     it('parses fragments with variable definitions', () => {
@@ -92,7 +96,7 @@ const assert = require('chai').assert;
 
       gql.disableExperimentalFragmentVariables()
     });
-    
+
     // see https://github.com/apollographql/graphql-tag/issues/168
     it('does not nest queries needlessly in named exports', () => {
       const jsSource = loader.call({ cacheable() {} }, `


### PR DESCRIPTION
ES6 modules expect the default export to be named `default`, rather
than using the `module.exports` object.  By providing an export named
`default` here, we make the module more directly compatible with ES6 modules.

The benefit of this is that when you import the default export in an ES6 environment
you won't get extra properties on the object for all the named exported operations
and fragments in the file.

This probably doesn't affect too many people, but it's a little cleanup that might save
some trouble / confusion for people who are importing a graphql module and doing more
with it than just feeding it into the apollo client.