### PR TITLE
Fix gql typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 declare module "graphql-tag" {
   function gql(
-    literals: ReadonlyArray<string>,
+    literals: ReadonlyArray<string> | Readonly<string>,
     ...placeholders: any[]
-  ): import("graphql").DocumentNode
+  ): import("graphql").DocumentNode;
 
   namespace gql {
     function resetCaches(): void;


### PR DESCRIPTION
It seems that the typings from `v2.10.2` are not  exactly as expected.

Based on what i see in the [`gql`](https://github.com/apollographql/graphql-tag/blob/master/src/index.js#L158) function, it seems that the `literals` parameter accepts an array of strings **or** a string.