### PR TITLE
Typescript expecting no arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,9 +149,7 @@ function disableExperimentalFragmentVariables() {
 }
 
 // XXX This should eventually disallow arbitrary string interpolation, like Relay does
-function gql(/* arguments */) {
-  var args = Array.prototype.slice.call(arguments);
-
+function gql(...args) {
   var literals = args[0];
 
   // We always get literals[0] and then matching post literals for each arg given


### PR DESCRIPTION
Use of the arguments keyword and having no parameters creates error in Typescript: `Expected 0 arguments, but got 1.`

This can be circumvented by defining function as type any: `(gql as any)`, however this breaks syntax highlighting in vscode.