### PR TITLE
Clearly identify that `graphql-tag` doesn't have side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### v2.11.0 (2020-07-28)
+
+* `package.json` `sideEffects` changes to clearly identify that `graphql-tag` doesn't have side effects.  <br/>
+  [@hwillson](http://github.com/hwillson) in [#313](https://github.com/apollographql/graphql-tag/pull/313)
+
 ### v2.10.4 (2020-07-08)
 
 * Bump dev/peer deps to accommodate `graphql` 15.  <br/>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "graphql-tag",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "description": "A JavaScript template literal tag that parses GraphQL queries",
   "main": "./lib/graphql-tag.umd.js",
   "module": "./src/index.js",
   "jsnext:main": "./src/index.js",
+  "sideEffects": false,
   "scripts": {
     "bundle": "rollup -c && cp src/index.js.flow lib/graphql-tag.umd.js.flow",
     "test": "mocha test/graphql.js",


### PR DESCRIPTION
This will help tree-shaking when used with projects that have a dependency on `graphql-tag` (like `@apollo/client`).

Reference: https://github.com/apollographql/apollo-client/issues/6687