### PR TITLE
Avoid TypeScript `import type ...` syntax for now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### v2.12.1
+
+* To accommodate older versions of TypeScript, usage of the `import type ...` syntax (introduced by [#325](https://github.com/apollographql/graphql-tag/pull/325)) has been removed, fixing issue [#345](https://github.com/apollographql/graphql-tag/issues/345). <br/>
+  [@benjamn](http://github.com/benjamn) in [#352](https://github.com/apollographql/graphql-tag/pull/352)
+
 ### v2.12.0
 
 * The `graphql-tag` repository has been converted to TypeScript, adding type safety and enabling both ECMAScript and CommonJS module exports. While these changes are intended to be as backwards-compatible as possible, we decided to bump the minor version to reflect the significant refactoring. <br/>

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "prebuild": "rimraf lib",
     "build": "tsc && rollup -c && npm run flow",
     "flow": "cp src/index.js.flow lib/graphql-tag.umd.js.flow",
-    "pretest": "npm run build",
-    "test": "mocha lib/tests.cjs.js",
+    "test": "npm run test:ts3 && npm run test:ts4",
+    "test:ts3": "npm i typescript@3.7.x && npm run build && npm run test:mocha",
+    "test:ts4": "npm i typescript@4.x && npm run build && npm run test:mocha",
+    "test:mocha": "mocha lib/tests.cjs.js",
     "prepublish": "npm run build"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "build": "tsc && rollup -c && npm run flow",
     "flow": "cp src/index.js.flow lib/graphql-tag.umd.js.flow",
     "test": "npm run test:ts3 && npm run test:ts4",
-    "test:ts3": "npm i typescript@3.7.x && npm run build && npm run test:mocha",
-    "test:ts4": "npm i typescript@4.x && npm run build && npm run test:mocha",
-    "test:mocha": "mocha lib/tests.cjs.js",
+    "test:ts3": "npm i typescript@3.7.x && npm run test:mocha",
+    "test:ts4": "npm i typescript@4.x && npm run test:mocha",
+    "test:mocha": "npm run build && mocha lib/tests.cjs.js",
     "prepublish": "npm run build"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { parse } from 'graphql';
 
-import type {
+import {
   DocumentNode,
   DefinitionNode,
   Location,

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 
 import { assert } from 'chai';
-import type { DocumentNode, FragmentDefinitionNode } from 'graphql';
+import { DocumentNode, FragmentDefinitionNode } from 'graphql';
 
 import gql from './index';
 const loader = require('../loader');


### PR DESCRIPTION
Should fix #345. Tested by running `npm i typescript@3.7.x` and verifying that the package still compiles and passes tests.