### PR TITLE
Make document cache configurable with lru-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,12 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.1.tgz",
@@ -1836,6 +1842,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -3360,6 +3375,12 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
       "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -37,20 +37,25 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",
+    "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.22",
     "chai": "^4.2.0",
     "graphql": "^15.4.0",
+    "lru-cache": "^6.0.0",
     "mocha": "^8.2.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.33.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "source-map-support": "^0.5.19",
     "test-all-versions": "^5.0.1",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.5"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
+  "optionalDependencies": {
+    "lru-cache": ">=5.0.0"
   },
   "engines": {
     "node": ">=10"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ const globals = {
   tslib: 'tslib',
   graphql: 'graphql',
   chai: 'chai',
+  'lru-cache': 'LRU',
   'source-map-support/register': 'sourceMapSupport',
 };
 

--- a/src/documentCache.ts
+++ b/src/documentCache.ts
@@ -1,5 +1,4 @@
-import LRU from 'lru-cache';
-
+import type { default as LRUCache } from 'lru-cache';
 import { DocumentNode } from 'graphql/language/ast';
 
 interface CacheClient<K, V> {
@@ -45,7 +44,9 @@ interface LRUCacheOptions {
  * in for the default unbounded Map
  * @param options 
  */
-function useLRUCache(lruOptions: LRUCacheOptions): void {
+async function useLRUCache(lruOptions: LRUCacheOptions): Promise<void> {
+    const LRU = require('lru-cache') as typeof LRUCache;
+
     const lru = new LRU<string, DocumentNode>({
         max: lruOptions.sizeInBytes || 64 * 1024 * 1024,
         maxAge: lruOptions.maxAgeMs,

--- a/src/documentCache.ts
+++ b/src/documentCache.ts
@@ -1,0 +1,85 @@
+import LRU from 'lru-cache';
+
+import { DocumentNode } from 'graphql/language/ast';
+
+interface CacheClient<K, V> {
+    has: (key: K) => boolean;
+    set: (key: K, value: V) => void;
+    get: (key: K) => V | undefined;
+    delete: (key: K) => boolean;
+    clear: () => void;
+}
+type DocCacheClient = CacheClient<string, DocumentNode>;
+
+/**
+ *  module-level cache client. Can be swapped out with a different implementation
+ */
+let docCache: DocCacheClient = new Map<string, DocumentNode>();
+
+/**
+ * Empties the existing cache entries and replaces the client
+ * with the provided DocCacheClient
+ * @param client 
+ */
+function setCacheClient(client: DocCacheClient): void {
+    docCache.clear();
+    docCache = client;
+}
+
+interface LRUCacheOptions {
+    /**
+     * Size of cache to use in memory. In bytes.
+     * @default (64 * 1024 * 1024) = 64Mb
+     */
+    sizeInBytes?: number;
+
+    /**
+     * Max length of time to leave a document in the cache. In milliseconds.
+     * @default: undefined (indefinite)
+     */
+    maxAgeMs?: number;
+}
+
+/**
+ * Creates an LRU cache with the specified size and age options then swap it
+ * in for the default unbounded Map
+ * @param options 
+ */
+function useLRUCache(lruOptions: LRUCacheOptions): void {
+    const lru = new LRU<string, DocumentNode>({
+        max: lruOptions.sizeInBytes || 64 * 1024 * 1024,
+        maxAge: lruOptions.maxAgeMs,
+        length: (val, key) => sizeOfCacheEntry(key, val)
+    });
+
+    const lruDocCache: DocCacheClient = {
+        clear: lru.reset,
+        delete: (key: string) => { 
+            const existed = lru.has(key);
+            lru.del(key);
+            return existed;
+        },
+        get: lru.get,
+        set: (key: string, value: DocumentNode) => {
+            lru.set(key, value);
+        },
+        has: lru.has
+    };
+
+    setCacheClient(lruDocCache);
+}
+
+/**
+ * Helper for LRUCache: Calculates the memory footprint of a single cache entry
+ */
+function sizeOfCacheEntry(key?: string, node?: DocumentNode): number {
+    const keySize: number = !!key ? (key.length * 2) : 0;
+    const nodeSize: number = !!node 
+        ?  (node.kind.length * 2) + (node.definitions.reduce((prev, cur) => prev + cur.kind.length * 2, 0))
+        : 0;
+
+    return keySize + nodeSize;
+}
+
+
+export { docCache, setCacheClient, useLRUCache, DocCacheClient, sizeOfCacheEntry };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -5,3 +5,5 @@ import type { DocumentNode } from 'graphql';
 declare export default function gql(literals: any, ...placeholders: any[]): DocumentNode;
 declare export function resetCaches(): void;
 declare export function disableFragmentWarnings(): void;
+declare export function useCacheClient(client: any): void;
+declare export function useLRUCache(lruOptions: any): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ import {
   Location,
 } from 'graphql/language/ast';
 
-// A map docString -> graphql document
-const docCache = new Map<string, DocumentNode>();
+import { docCache, setCacheClient, useLRUCache } from './documentCache';
 
 // A map fragmentName -> [normalized source]
 const fragmentSourceMap = new Map<string, Set<string>>();
@@ -157,4 +156,6 @@ export default Object.assign(gql, {
   disableFragmentWarnings,
   enableExperimentalFragmentVariables,
   disableExperimentalFragmentVariables,
+  setCacheClient,
+  useLRUCache
 });


### PR DESCRIPTION
Adds support for swapping out the use of a Map in exchange for a custom cache client. Defines interfaces to allow users to implement their own cache. Adds easy out of the box support for lru-cache with sane defaults.

Fixes #356