### PR TITLE
Loader: allow a space between `#` and `import` word in gql files

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -27,8 +27,9 @@ function expandImports(source, doc) {
   `;
 
   lines.some((line) => {
-    if (line[0] === '#' && line.slice(1).split(' ')[0] === 'import') {
-      const importFile = line.slice(1).split(' ')[1];
+    const result = line.match(/^#\s?import (.+)$/);
+    if (result) {
+      const importFile = result[1];
       const parseDocument = `require(${importFile})`;
       const appendDef = `doc.definitions = doc.definitions.concat(unique(${parseDocument}.definitions));`;
       outputCode += appendDef + os.EOL;

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -236,6 +236,31 @@ describe('gql', () => {
     assert.equal(definitions[1].kind, 'FragmentDefinition');
   });
 
+  it('importing files also works with a space between `#` and `import`', () => {
+    const query = `# import "./fragment_definition.graphql"
+      query {
+        author {
+          ...authorDetails
+        }
+      }`;
+    const jsSource = loader.call({ cacheable() {} }, query);
+    const module = { exports: Object.create(null) };
+    const require = (path: string) => {
+      assert.equal(path, './fragment_definition.graphql');
+      return gql`
+        fragment authorDetails on Author {
+          firstName
+          lastName
+        }`;
+    };
+    Function("module,require", jsSource)(module, require);
+    assert.equal(module.exports.kind, 'Document');
+    const definitions = module.exports.definitions;
+    assert.equal(definitions.length, 2);
+    assert.equal(definitions[0].kind, 'OperationDefinition');
+    assert.equal(definitions[1].kind, 'FragmentDefinition');
+  });
+
   it('tracks fragment dependencies across fragments loaded via the webpack loader', () => {
     const query = `#import "./fragment_definition.graphql"
       fragment F111 on F {


### PR DESCRIPTION
Allow the webpack loader to distinct imports written with a space like:

```gql
# import "./some/file.graphql"
```

I've stumbled on this while migrating a parcel project to webpack
In parcel imports work with a space, like in the example here: https://en.parceljs.org/graphQL.html#graphql

The change here allows for both `#import` and `# import` syntax to work