### PR TITLE
Add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "./main.js",
   "module": "./lib/index.js",
   "jsnext:main": "./lib/index.js",
+  "exports": {
+    "require": "./main.js",
+    "import": "./lib/index.js"
+  },
   "types": "./lib/index.d.ts",
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
https://nodejs.org/api/packages.html#conditional-exports

This should help with import errors in environments where `module` is not supported, but `exports.import` is.