### PR TITLE
Adding exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "module": "./lib/index.js",
   "jsnext:main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./main.js",
+      "import": "./lib/index.js"
+    },
+    "./*": "./*"
+  },
   "sideEffects": false,
   "scripts": {
     "prebuild": "rimraf lib",


### PR DESCRIPTION
``graphql-tag`` working with ``ssr`` will be throwing `` Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.``

The full exception in here.
```
(node:7884) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/zc/projects/foo/node_modules/tslib/tslib.es6.js:24
export function __extends(d, b) {
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
    at ModuleJob.run (internal/modules/esm/module_job.js:183:25)
    at async Loader.import (internal/modules/esm/loader.js:178:24)
    at async __instantiateModule__ (file:///Users/zc/projects/foo/.nuxt/dist/server/server.mjs:12083:3)
[vite dev] Error loading external "/Users/zc/projects/foo/node_modules/tslib/tslib.es6.js".
  at file://./.nuxt/dist/server/server.mjs:6149:277  
  at async __instantiateModule__ (file://./.nuxt/dist/server/server.mjs:12083:3)
[vite dev] Error loading external "/Users/zc/projects/foo/node_modules/tslib/tslib.es6.js".
  at file://./.nuxt/dist/server/server.mjs:6149:277  
  at async __instantiateModule__ (file://./.nuxt/dist/server/server.mjs:12083:3)

```

[reworked ](https://github.com/apollographql/graphql-tag/pull/527)