### PR TITLE
fix: align cjs/esm hybrid exports

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
 // For backwards compatibility, make sure require("graphql-tag") returns
 // the gql function, rather than an exports object.
-module.exports = require('./lib/graphql-tag.umd.js').gql;
+const gql = require('./lib/graphql-tag.umd.js').gql
+module.exports = gql.gql = gql


### PR DESCRIPTION
Hello,

i have been trying to get [dagger.io](https://dagger.io/) running on deno and i have stumbled on an issue importing graphql-tag in deno.
See: https://github.com/denoland/deno/issues/25311

graphql-tag bundles into an umd.js file that masquerades as an esm-module by having a "default"  and __esModule property. But package.json declares another the ./main.js as it's primary module. This one exclude all of the umd bundle and simply exports the `gql` function.

graphql-tag hasn't seen an update published in 3 years and there is properly much more todo to renovate the build process.

This PR alleviates the problem with being a hybrid package a little bit without breaking legacy imports.

Thank you for reading!